### PR TITLE
Feat: color preview in variables (#13)

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,13 +107,15 @@
     "vscode": "^1.1.0"
   },
   "dependencies": {
+    "color": "3.0.0",
+    "color-name": "1.1.3",
+    "micromatch": "3.0.3",
+    "readdir-enhanced": "1.5.2",
+    "scss-symbols-parser": "1.1.3",
     "vscode-languageclient": "3.3.0",
     "vscode-languageserver": "3.3.0",
     "vscode-css-languageservice": "2.1.0",
-    "vscode-uri": "1.0.0",
-    "readdir-enhanced": "1.5.2",
-    "micromatch": "3.0.3",
-    "scss-symbols-parser": "1.1.3"
+    "vscode-uri": "1.0.0"
   },
   "scripts": {
     "postinstall": "node ./node_modules/vscode/bin/install",

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -16,6 +16,7 @@ import { parseDocument } from '../services/parser';
 import { getSymbolsCollection } from '../utils/symbols';
 import { getCurrentDocumentImportPaths, getDocumentPath } from '../utils/document';
 import { getCurrentWord, getLimitedString, getTextBeforePosition } from '../utils/string';
+import { getVariableColor } from '../utils/color';
 
 // RegExp's
 const rePropertyValue = /.*:\s*/;
@@ -141,6 +142,9 @@ export function doCompletion(document: TextDocument, offset: number, settings: I
 			const isImplicitlyImport = isImplicitly(symbols.document, documentPath, documentImports);
 
 			symbols.variables.forEach((variable) => {
+				const color = getVariableColor(variable.value);
+				const completionKind = color ? CompletionItemKind.Color : CompletionItemKind.Variable;
+
 				// Add 'implicitly' prefix for Path if the file imported implicitly
 				let detailPath = fsPath;
 				if (isImplicitlyImport && settings.implicitlyLabel) {
@@ -155,9 +159,9 @@ export function doCompletion(document: TextDocument, offset: number, settings: I
 
 				completions.items.push({
 					label: variable.name,
-					kind: CompletionItemKind.Variable,
+					kind: completionKind,
 					detail: detailText,
-					documentation: getLimitedString(variable.value)
+					documentation: getLimitedString(color ? color.toString() : variable.value)
 				});
 			});
 		});

--- a/src/server.ts
+++ b/src/server.ts
@@ -50,7 +50,7 @@ connection.onInitialize((params: InitializeParams): Promise<InitializeResult> =>
 	settings = params.initializationOptions.settings;
 	activeDocumentUri = params.initializationOptions.activeEditorUri;
 
-	return doScanner(workspaceRoot, cache, settings).then(() => {
+	return <Promise<InitializeResult>>doScanner(workspaceRoot, cache, settings).then(() => {
 		return <InitializeResult>{
 			capabilities: {
 				textDocumentSync: documents.syncKind,

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,0 +1,104 @@
+'use strict';
+// Copied/mutated from https://github.com/sergiirocks/vscode-ext-color-highlight/tree/master/src/strategies
+
+import * as Color from 'color';
+import * as webColors from 'color-name';
+
+const colorHex = /.?(\#([a-f0-9]{6}([a-f0-9]{2})?|[a-f0-9]{3}([a-f0-9]{1})?))\b/gi;
+const colorFunctions = /((rgb|hsl)a?\([\d]{1,3}%?,\s*[\d]{1,3}%?,\s*[\d]{1,3}%?(,\s*\d?\.?\d+)?\))/gi;
+
+const preparedRePart = Object.keys(webColors).map((color) => `\\b${color}\\b`).join('|');
+
+const colorWeb = new RegExp('.?(' + preparedRePart + ')(?!-)', 'g');
+
+export function getVariableColor(value): string[] {
+	const hex = findHex(value);
+	const fn = findFn(value);
+	const words = findWords(value);
+
+	if (hex.length) {
+		return hex;
+	}
+	if (fn.length) {
+		return fn;
+	}
+	if (words.length) {
+		return words;
+	}
+
+	return null;
+}
+
+/*
+ * Find color from hexcode
+ */
+export function findHex(text): string[] {
+	let match = colorHex.exec(text);
+	const result = [];
+
+	while (match !== null) {
+		const matchedColor = match[1];
+
+		try {
+			const color = Color(matchedColor).hex();
+
+			result.push(color);
+		} catch (e) {
+			console.error(e);
+		}
+
+		match = colorHex.exec(text);
+	}
+
+	return result;
+}
+
+/**
+ * Find color from rgb/hsl
+ */
+export function findFn(text): string[] {
+	let match = colorFunctions.exec(text);
+	const result = [];
+
+	while (match !== null) {
+		const color = match[0];
+
+		result.push(color);
+
+		match = colorFunctions.exec(text);
+	}
+
+	return result;
+}
+
+/**
+ * Find color from words
+ */
+export function findWords(text): string[] {
+	let match = colorWeb.exec(text);
+	const result = [];
+
+	while (match !== null) {
+		const firstChar = match[0][0];
+		const matchedColor = match[1];
+
+		if (firstChar.length && /[-\\$@#]/.test(firstChar)) {
+			match = colorWeb.exec(text);
+			continue;
+		}
+
+		try {
+			const color = Color(matchedColor)
+				.rgb()
+				.string();
+
+			result.push(color);
+		} catch (e) {
+			console.error(e);
+		}
+
+		match = colorWeb.exec(text);
+	}
+
+	return result;
+}

--- a/tslint.json
+++ b/tslint.json
@@ -8,7 +8,7 @@
 		"member-ordering": [
 			true,
 			{
-				"order": ["public-before-private", "static-before-instance", "variables-before-functions"]
+				"order": "fields-first"
 			}
 		],
 		"no-inferrable-types": [true, "ignore-params"],
@@ -27,6 +27,8 @@
 		"number-literal-format": false,
 		"no-return-await": false,
 		"space-within-parens": false,
-		"no-irregular-whitespace": false
+		"no-irregular-whitespace": false,
+		"no-unused-variable": false,
+		"no-use-before-declare": false
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -279,7 +279,7 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^1.9.0:
+color-convert@^1.9.0, color-convert@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -290,6 +290,27 @@ color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+
+color-name@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-string@^1.5.2:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.5.3.tgz#c9bbc5f01b58b5492f3d6857459cb6590ce204cc"
+  integrity sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
+color@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.0.0.tgz#d920b4328d534a3ac8295d68f7bd4ba6c427be9a"
+  integrity sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==
+  dependencies:
+    color-convert "^1.9.1"
+    color-string "^1.5.2"
 
 colors@^1.1.2:
   version "1.4.0"
@@ -781,6 +802,11 @@ is-accessor-descriptor@^1.0.0:
   integrity sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==
   dependencies:
     kind-of "^6.0.0"
+
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
 
 is-buffer@^1.1.5:
   version "1.1.6"
@@ -1368,6 +1394,13 @@ set-value@^2.0.0, set-value@^2.0.1:
     is-extendable "^0.1.1"
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
+
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=
+  dependencies:
+    is-arrayish "^0.3.1"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"


### PR DESCRIPTION
First cut at providing this. Borrowed the color parsing code from https://github.com/sergiirocks/vscode-ext-color-highlight/tree/master/src/strategies so currently it works for hexcodes, rgb, hsl, and "words" (red, blue, etc). 

I know in #13 someone recommends using [this](https://github.com/Microsoft/vscode-css-languageservice/blob/master/src/services/cssNavigation.ts#L134) but I can't see a way to get this to work. 

I realise at this point that this is nowhere near 100% color type coverage - for instance, it doesn't handle Sass functions (`$lighten`, `$darken`, etc) - but this is a starting point. 


