### PR TITLE
Don't auto open the output console

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -7,7 +7,8 @@ import {
 	LanguageClient,
 	LanguageClientOptions,
 	ServerOptions,
-	TransportKind
+	TransportKind,
+	RevealOutputChannelOn
 } from 'vscode-languageclient';
 
 export function activate(context: vscode.ExtensionContext) {
@@ -40,7 +41,11 @@ export function activate(context: vscode.ExtensionContext) {
 		initializationOptions: {
 			settings: vscode.workspace.getConfiguration('scss'),
 			activeEditorUri: activeEditor ? activeEditor.document.uri.toString() : null
-		}
+		},
+
+		// Don't open the output console
+		// automatically because of us
+		revealOutputChannelOn: RevealOutputChannelOn.Never,
 	};
 
 	const client = new LanguageClient('scss-intellisense', 'SCSS IntelliSense', serverOptions, clientOptions);


### PR DESCRIPTION
This should fix the complaint in Issue #70 about the output console opening/focusing automatically