### PR TITLE
Show initialization progress

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -50,7 +50,7 @@ export function activate(context: vscode.ExtensionContext) {
 	const client = new LanguageClient('scss-intellisense', 'SCSS IntelliSense', serverOptions, clientOptions);
 	context.subscriptions.push(client.start());
 
-	client
+	const promise = client
 		.onReady()
 		.then(() => {
 			const disposable = vscode.window.onDidChangeActiveTextEditor(event => {
@@ -68,4 +68,12 @@ export function activate(context: vscode.ExtensionContext) {
 			console.log('Client initialization failed');
 			console.error(e);
 		});
+
+	return vscode.window.withProgress(
+		{
+			title: 'SCSS IntelliSense initialization',
+			location: vscode.ProgressLocation.Window
+		},
+		() => promise
+	);
 }


### PR DESCRIPTION
This can be useful for displaying the current state of the plugin.

Related to #73.

![Annotation 2019-11-13 220906](https://user-images.githubusercontent.com/7034281/68795535-3d1b9180-0662-11ea-8630-a0a77c6bc711.png)
