### PR TITLE
Update "scss-symbols-parser" package

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
 		"color": "3.0.0",
 		"color-name": "1.1.3",
 		"fast-glob": "3.1.0",
-		"scss-symbols-parser": "1.1.3",
+		"scss-symbols-parser": "2.0.1",
 		"vscode-css-languageservice": "2.1.0",
 		"vscode-languageclient": "^5.2.1",
 		"vscode-languageserver": "^5.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1593,10 +1593,10 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-scss-symbols-parser@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/scss-symbols-parser/-/scss-symbols-parser-1.1.3.tgz#5708d5584d8e402fc7cbdf9b87af3ba61bcc36d4"
-  integrity sha1-VwjVWE2OQC/Hy9+bh687phvMNtQ=
+scss-symbols-parser@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/scss-symbols-parser/-/scss-symbols-parser-2.0.1.tgz#b1848eaefdf57b7d7a290868b55f3287fd186b11"
+  integrity sha512-6SHG9TUY0PWyR2Le7qiyBCqmpcZajFv7GdMW5xKeGu7TCiRFzoeFFDEH9WfM4uWMS/UCmrfmYSgwOpyhQkcOkg==
 
 semver-compare@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This version has two fixes:

#### Fix incorrect early exit for unsupported at-rules

Related to Bootstrap@4+.

```scss
$grid-breakpoints: (
  xs: 0,
  sm: 576px,
  md: 768px,
  lg: 992px,
  xl: 1200px
) !default;

@include _assert-ascending($grid-breakpoints, "$grid-breakpoints"); // The parser broke down here
@include _assert-starts-at-zero($grid-breakpoints, "$grid-breakpoints");

$container-max-widths: (
  sm: 540px,
  md: 720px,
  lg: 960px,
  xl: 1140px
) !default;

@include _assert-ascending($container-max-widths, "$container-max-widths");
```

#### Fix mixin parsing without parameters

```scss
@mixin f {
	border-top: 0;
	border-right: $a solid transparent;  // previously it was considered a global variable
}
```