### PR TITLE
ISSUE-99: use "findDocumentLinks2" method

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,10 +95,11 @@
 		}
 	},
 	"devDependencies": {
+		"@nodelib/fs.macchiato": "^1.0.2",
 		"@types/glob": "^7.1.1",
 		"@types/micromatch": "^3.1.0",
 		"@types/mocha": "^5.2.7",
-		"@types/node": "^7.0.31",
+		"@types/node": "10.17.6",
 		"@types/parse-glob": "^3.0.29",
 		"@types/sinon": "^7.5.0",
 		"@types/vscode": "1.30.0",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
 		"vscode-languageclient": "^5.2.1",
 		"vscode-languageserver": "^5.2.1",
 		"vscode-languageserver-types": "^3.14.0",
-		"vscode-uri": "1.0.0"
+		"vscode-uri": "^2.1.1"
 	},
 	"scripts": {
 		"clean": "rimraf out",

--- a/src/language-service.ts
+++ b/src/language-service.ts
@@ -1,0 +1,61 @@
+import {
+	LanguageService,
+	FileSystemProvider,
+	FileType,
+	getSCSSLanguageService,
+	ICompletionParticipant
+} from 'vscode-css-languageservice';
+import { URI } from 'vscode-uri';
+
+import { statFile } from './utils/fs';
+
+const fileSystemProvider: FileSystemProvider = {
+	async stat(uri: string) {
+		const filePath = URI.parse(uri).fsPath;
+
+		try {
+			const stats = await statFile(filePath);
+
+			let type = FileType.Unknown;
+			if (stats.isFile()) {
+				type = FileType.File;
+			} else if (stats.isDirectory()) {
+				type = FileType.Directory;
+			} else if (stats.isSymbolicLink()) {
+				type = FileType.SymbolicLink;
+			}
+
+			return {
+				type,
+				ctime: stats.ctime.getTime(),
+				mtime: stats.mtime.getTime(),
+				size: stats.size
+			};
+		} catch (error) {
+			if (error.code !== 'ENOENT') {
+				throw error;
+			}
+
+			return {
+				type: FileType.Unknown,
+				ctime: -1,
+				mtime: -1,
+				size: -1
+			};
+		}
+	}
+};
+
+export function getLanguageService(completionParticipants?: ICompletionParticipant[]): LanguageService {
+	const ls = getSCSSLanguageService({ fileSystemProvider });
+
+	if (completionParticipants !== undefined) {
+		ls.setCompletionParticipants(completionParticipants);
+	}
+
+	ls.configure({
+		validate: false
+	});
+
+	return ls;
+}

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -221,15 +221,12 @@ function createFunctionCompletionItems(
 	return completions;
 }
 
-/**
- * Do Completion :)
- */
-export function doCompletion(
+export async function doCompletion(
 	document: TextDocument,
 	offset: number,
 	settings: ISettings,
 	storage: StorageService
-): CompletionList {
+): Promise<CompletionList> {
 	const completions = CompletionList.create([], false);
 
 	const documentPath = Files.uriToFilePath(document.uri) || document.uri;

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -234,7 +234,7 @@ export async function doCompletion(
 		return null;
 	}
 
-	const resource = parseDocument(document, offset);
+	const resource = await parseDocument(document, offset);
 
 	storage.set(documentPath, resource.symbols);
 

--- a/src/providers/goDefinition.ts
+++ b/src/providers/goDefinition.ts
@@ -56,7 +56,7 @@ export async function goDefinition(document: TextDocument, offset: number, stora
 		return null;
 	}
 
-	const resource = parseDocument(document, offset);
+	const resource = await parseDocument(document, offset);
 	const hoverNode = resource.node;
 	if (!hoverNode || !hoverNode.type) {
 		return null;

--- a/src/providers/goDefinition.ts
+++ b/src/providers/goDefinition.ts
@@ -50,19 +50,16 @@ function getSymbols(symbolList: ISymbols[], identifier: IIdentifier, currentPath
 	return list;
 }
 
-/**
- * Do Go Definition :)
- */
-export function goDefinition(document: TextDocument, offset: number, storage: StorageService): Promise<Location> {
+export async function goDefinition(document: TextDocument, offset: number, storage: StorageService): Promise<Location> {
 	const documentPath = Files.uriToFilePath(document.uri) || document.uri;
 	if (!documentPath) {
-		return Promise.resolve(null);
+		return null;
 	}
 
 	const resource = parseDocument(document, offset);
 	const hoverNode = resource.node;
 	if (!hoverNode || !hoverNode.type) {
-		return Promise.resolve(null);
+		return null;
 	}
 
 	let identifier: IIdentifier = null;
@@ -98,7 +95,7 @@ export function goDefinition(document: TextDocument, offset: number, storage: St
 	}
 
 	if (!identifier) {
-		return Promise.resolve(null);
+		return null;
 	}
 
 	storage.set(resource.symbols.document, resource.symbols);
@@ -108,7 +105,7 @@ export function goDefinition(document: TextDocument, offset: number, storage: St
 	// Symbols
 	const candidates = getSymbols(symbolsList, identifier, documentPath);
 	if (candidates.length === 0) {
-		return Promise.resolve(null);
+		return null;
 	}
 
 	const definition = candidates[0];
@@ -121,5 +118,5 @@ export function goDefinition(document: TextDocument, offset: number, storage: St
 		}
 	});
 
-	return Promise.resolve(symbol);
+	return symbol;
 }

--- a/src/providers/goDefinition.ts
+++ b/src/providers/goDefinition.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import { TextDocument, Location, Position, Files } from 'vscode-languageserver';
-import Uri from 'vscode-uri';
+import { URI } from 'vscode-uri';
 
 import { NodeType } from '../types/nodes';
 import { ISymbols } from '../types/symbols';
@@ -110,7 +110,7 @@ export async function goDefinition(document: TextDocument, offset: number, stora
 
 	const definition = candidates[0];
 
-	const symbol = Location.create(Uri.file(definition.document).toString(), {
+	const symbol = Location.create(URI.file(definition.document).toString(), {
 		start: definition.info.position,
 		end: {
 			line: definition.info.position.line,

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -88,10 +88,7 @@ function getSymbol(symbolList: ISymbols[], identifier: any, currentPath: string)
 	return null;
 }
 
-/**
- * Do Hover :)
- */
-export function doHover(document: TextDocument, offset: number, storage: StorageService): Hover | null {
+export async function doHover(document: TextDocument, offset: number, storage: StorageService): Promise<Hover | null> {
 	const documentPath = Files.uriToFilePath(document.uri) || document.uri;
 	if (!documentPath) {
 		return null;

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -94,7 +94,7 @@ export async function doHover(document: TextDocument, offset: number, storage: S
 		return null;
 	}
 
-	const resource = parseDocument(document, offset);
+	const resource = await parseDocument(document, offset);
 	const hoverNode = resource.node;
 	if (!hoverNode || !hoverNode.type) {
 		return null;

--- a/src/providers/signatureHelp.ts
+++ b/src/providers/signatureHelp.ts
@@ -168,7 +168,7 @@ export async function doSignatureHelp(
 
 	const symbolType = textBeforeWord.indexOf('@include') !== -1 ? 'mixins' : 'functions';
 
-	const resource = parseDocument(document, offset);
+	const resource = await parseDocument(document, offset);
 
 	storage.set(documentPath, resource.symbols);
 

--- a/src/providers/signatureHelp.ts
+++ b/src/providers/signatureHelp.ts
@@ -137,10 +137,11 @@ function parseArgumentsAtLine(text: string): IMixinEntry {
 	};
 }
 
-/**
- * Do Signature Help :)
- */
-export function doSignatureHelp(document: TextDocument, offset: number, storage: StorageService): SignatureHelp {
+export async function doSignatureHelp(
+	document: TextDocument,
+	offset: number,
+	storage: StorageService
+): Promise<SignatureHelp> {
 	const suggestions: { name: string; parameters: IVariable[] }[] = [];
 
 	const ret: SignatureHelp = {

--- a/src/providers/workspaceSymbol.ts
+++ b/src/providers/workspaceSymbol.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import { SymbolInformation, SymbolKind } from 'vscode-languageserver';
-import Uri from 'vscode-uri';
+import { URI } from 'vscode-uri';
 
 import StorageService from '../services/storage';
 import { getSymbolsCollection } from '../utils/symbols';
@@ -14,7 +14,7 @@ export async function searchWorkspaceSymbol(
 	const workspaceSymbols: SymbolInformation[] = [];
 
 	getSymbolsCollection(storage).forEach(symbols => {
-		const documentUri = Uri.file(symbols.filepath);
+		const documentUri = URI.file(symbols.filepath);
 		if (!documentUri.fsPath.includes(root)) {
 			return;
 		}

--- a/src/providers/workspaceSymbol.ts
+++ b/src/providers/workspaceSymbol.ts
@@ -6,10 +6,11 @@ import Uri from 'vscode-uri';
 import StorageService from '../services/storage';
 import { getSymbolsCollection } from '../utils/symbols';
 
-/**
- * All Symbol Definitions in Folder :)
- */
-export function searchWorkspaceSymbol(query: string, storage: StorageService, root: string): SymbolInformation[] {
+export async function searchWorkspaceSymbol(
+	query: string,
+	storage: StorageService,
+	root: string
+): Promise<SymbolInformation[]> {
 	const workspaceSymbols: SymbolInformation[] = [];
 
 	getSymbolsCollection(storage).forEach(symbols => {

--- a/src/services/parser.ts
+++ b/src/services/parser.ts
@@ -1,65 +1,18 @@
 'use strict';
 
 import { TextDocument, Files } from 'vscode-languageserver';
-import {
-	getSCSSLanguageService,
-	SymbolKind,
-	DocumentLink,
-	FileType,
-	FileSystemProvider
-} from 'vscode-css-languageservice';
+import { SymbolKind, DocumentLink } from 'vscode-css-languageservice';
 import { URI } from 'vscode-uri';
 
 import { INode, NodeType } from '../types/nodes';
 import { IDocument, ISymbols, IVariable, IImport } from '../types/symbols';
 import { getNodeAtOffset, getParentNodeByType } from '../utils/ast';
-import { statFile } from '../utils/fs';
 import { buildDocumentContext } from '../utils/document';
+import { getLanguageService } from '../language-service';
 
 const reDynamicPath = /[#{}\*]/;
 
-const fileSystemProvider: FileSystemProvider = {
-	async stat(uri: string) {
-		const filePath = URI.parse(uri).fsPath;
-
-		try {
-			const stats = await statFile(filePath);
-
-			let type = FileType.Unknown;
-			if (stats.isFile()) {
-				type = FileType.File;
-			} else if (stats.isDirectory()) {
-				type = FileType.Directory;
-			} else if (stats.isSymbolicLink()) {
-				type = FileType.SymbolicLink;
-			}
-
-			return {
-				type,
-				ctime: stats.ctime.getTime(),
-				mtime: stats.mtime.getTime(),
-				size: stats.size
-			};
-		} catch (error) {
-			if (error.code !== 'ENOENT') {
-				throw error;
-			}
-
-			return {
-				type: FileType.Unknown,
-				ctime: -1,
-				mtime: -1,
-				size: -1
-			};
-		}
-	}
-};
-
-const ls = getSCSSLanguageService({ fileSystemProvider });
-
-ls.configure({
-	validate: false
-});
+const ls = getLanguageService();
 
 /**
  * Returns all Symbols in a single document.

--- a/src/services/parser.ts
+++ b/src/services/parser.ts
@@ -24,7 +24,7 @@ ls.configure({
 /**
  * Returns all Symbols in a single document.
  */
-export function parseDocument(document: TextDocument, offset: number = null): IDocument {
+export async function parseDocument(document: TextDocument, offset: number = null): Promise<IDocument> {
 	const ast = ls.parseStylesheet(document) as INode;
 	const documentPath = Files.uriToFilePath(document.uri) || document.uri;
 

--- a/src/services/scanner.ts
+++ b/src/services/scanner.ts
@@ -38,7 +38,7 @@ export default class ScannerService {
 
 			const content = await this._readFile(filepath);
 			const document = TextDocument.create(originalFilepath, 'scss', 1, content);
-			const { symbols } = parseDocument(document, null);
+			const { symbols } = await parseDocument(document, null);
 
 			this._storage.set(filepath, { ...symbols, filepath });
 

--- a/src/services/scanner.ts
+++ b/src/services/scanner.ts
@@ -17,27 +17,16 @@ export default class ScannerService {
 			// Cast to the system file path style
 			filepath = path.normalize(filepath);
 
-			const originalFilepath = filepath;
-
-			let isExistFile = await this._fileExists(filepath);
-
-			const partialFilepath = this._formatPartialFilepath(filepath);
-			const isPartialFile = filepath === partialFilepath;
-
-			if (!isExistFile && !isPartialFile) {
-				filepath = partialFilepath;
-				isExistFile = await this._fileExists(filepath);
-			}
+			const isExistFile = await this._fileExists(filepath);
 
 			if (!isExistFile) {
-				this._storage.delete(originalFilepath);
-				this._storage.delete(partialFilepath);
+				this._storage.delete(filepath);
 
 				continue;
 			}
 
 			const content = await this._readFile(filepath);
-			const document = TextDocument.create(originalFilepath, 'scss', 1, content);
+			const document = TextDocument.create(filepath, 'scss', 1, content);
 			const { symbols } = await parseDocument(document, null);
 
 			this._storage.set(filepath, { ...symbols, filepath });
@@ -62,17 +51,5 @@ export default class ScannerService {
 
 	protected _fileExists(filepath: string): Promise<boolean> {
 		return fileExists(filepath);
-	}
-
-	private _formatPartialFilepath(filepath: string): string {
-		const original = path.parse(filepath);
-
-		const hasUnderscorePrefix = original.base[0] === '_';
-		const base = hasUnderscorePrefix ? original.base : `_${original.base}`;
-
-		return path.format({
-			...original,
-			base
-		});
 	}
 }

--- a/src/test/e2e/suite/completion/completion.test.ts
+++ b/src/test/e2e/suite/completion/completion.test.ts
@@ -18,6 +18,6 @@ describe('SCSS Completion Test', () => {
 	});
 
 	it('Offers completions from partial file', async () => {
-		await testCompletion(docUri, position(17, 11), [{ label: '$partial', detail: 'partial.scss' }]);
+		await testCompletion(docUri, position(17, 11), [{ label: '$partial', detail: '_partial.scss' }]);
 	});
 });

--- a/src/test/language-service.spec.ts
+++ b/src/test/language-service.spec.ts
@@ -1,0 +1,28 @@
+import * as assert from 'assert';
+
+import * as sinon from 'sinon';
+import { Position } from 'vscode-languageserver';
+
+import * as ls from '../language-service';
+import { makeDocument } from './helpers';
+
+describe('LanguageService', () => {
+	describe('.getLanguageService', () => {
+		it('should return language service', () => {
+			const actual = ls.getLanguageService();
+
+			assert.notStrictEqual(actual.configure, undefined);
+		});
+
+		it('should return language service with completion participans', () => {
+			const onCssPropertyValue = sinon.stub();
+			const document = makeDocument('.test { content: ');
+
+			const languageService = ls.getLanguageService([{ onCssPropertyValue }]);
+
+			languageService.doComplete(document, Position.create(1, 17), languageService.parseStylesheet(document));
+
+			assert.ok(onCssPropertyValue.calledOnce);
+		});
+	});
+});

--- a/src/test/providers/completion.spec.ts
+++ b/src/test/providers/completion.spec.ts
@@ -30,7 +30,7 @@ storage.set('one.scss', {
 	imports: []
 });
 
-function getCompletionList(lines: string[], options?: Partial<ISettings>): CompletionList {
+function getCompletionList(lines: string[], options?: Partial<ISettings>): Promise<CompletionList> {
 	const text = lines.join('\n');
 
 	const settings = helpers.makeSettings(options);
@@ -41,40 +41,40 @@ function getCompletionList(lines: string[], options?: Partial<ISettings>): Compl
 }
 
 describe('Providers/Completion - Basic', () => {
-	it('Variables', () => {
-		const actual = getCompletionList(['$|']);
+	it('Variables', async () => {
+		const actual = await getCompletionList(['$|']);
 
 		assert.equal(actual.items.length, 5);
 	});
 
-	it('Mixins', () => {
-		const actual = getCompletionList(['@include |']);
+	it('Mixins', async () => {
+		const actual = await getCompletionList(['@include |']);
 
 		assert.equal(actual.items.length, 1);
 	});
 });
 
-describe('Providers/Completion - Context', () => {
-	it('Empty property value', () => {
-		const actual = getCompletionList(['.a { content: | }']);
+describe('Providers/Completion - Context', async () => {
+	it('Empty property value', async () => {
+		const actual = await getCompletionList(['.a { content: | }']);
 
 		assert.equal(actual.items.length, 5);
 	});
 
-	it('Non-empty property value without suggestions', () => {
-		const actual = getCompletionList(['.a { background: url(../images/one|.png); }']);
+	it('Non-empty property value without suggestions', async () => {
+		const actual = await getCompletionList(['.a { background: url(../images/one|.png); }']);
 
 		assert.equal(actual.items.length, 0);
 	});
 
-	it('Non-empty property value with Variables', () => {
-		const actual = getCompletionList(['.a { background: url(../images/#{$one|}/one.png); }']);
+	it('Non-empty property value with Variables', async () => {
+		const actual = await getCompletionList(['.a { background: url(../images/#{$one|}/one.png); }']);
 
 		assert.equal(actual.items.length, 5);
 	});
 
-	it('Discard suggestions inside quotes', () => {
-		const actual = getCompletionList([
+	it('Discard suggestions inside quotes', async () => {
+		const actual = await getCompletionList([
 			'.a {',
 			'    background: url("../images/#{$one}/$one|.png");',
 			'}'
@@ -83,28 +83,28 @@ describe('Providers/Completion - Context', () => {
 		assert.equal(actual.items.length, 0);
 	});
 
-	it('Custom value for `suggestFunctionsInStringContextAfterSymbols` option', () => {
-		const actual = getCompletionList(['.a { background: url(../images/m|'], {
+	it('Custom value for `suggestFunctionsInStringContextAfterSymbols` option', async () => {
+		const actual = await getCompletionList(['.a { background: url(../images/m|'], {
 			suggestFunctionsInStringContextAfterSymbols: '/'
 		});
 
 		assert.equal(actual.items.length, 1);
 	});
 
-	it('Discard suggestions inside single-line comments', () => {
-		const actual = getCompletionList(['// $|']);
+	it('Discard suggestions inside single-line comments', async () => {
+		const actual = await getCompletionList(['// $|']);
 
 		assert.equal(actual.items.length, 0);
 	});
 
-	it('Discard suggestions inside block comments', () => {
-		const actual = getCompletionList(['/* $| */']);
+	it('Discard suggestions inside block comments', async () => {
+		const actual = await getCompletionList(['/* $| */']);
 
 		assert.equal(actual.items.length, 0);
 	});
 
-	it('Identify color variables', () => {
-		const actual = getCompletionList(['$|']);
+	it('Identify color variables', async () => {
+		const actual = await getCompletionList(['$|']);
 
 		assert.equal(actual.items[0].kind, CompletionItemKind.Variable);
 		assert.equal(actual.items[1].kind, CompletionItemKind.Variable);
@@ -115,22 +115,22 @@ describe('Providers/Completion - Context', () => {
 });
 
 describe('Providers/Completion - Implicitly', () => {
-	it('Show default implicitly label', () => {
-		const actual = getCompletionList(['$|']);
+	it('Show default implicitly label', async () => {
+		const actual = await getCompletionList(['$|']);
 
 		assert.equal(actual.items[0].detail, '(implicitly) one.scss');
 	});
 
-	it('Show custom implicitly label', () => {
-		const actual = getCompletionList(['$|'], {
+	it('Show custom implicitly label', async () => {
+		const actual = await getCompletionList(['$|'], {
 			implicitlyLabel: '👻'
 		});
 
 		assert.equal(actual.items[0].detail, '👻 one.scss');
 	});
 
-	it('Hide implicitly label', () => {
-		const actual = getCompletionList(['$|'], {
+	it('Hide implicitly label', async () => {
+		const actual = await getCompletionList(['$|'], {
 			implicitlyLabel: null
 		});
 

--- a/src/test/providers/hover.spec.ts
+++ b/src/test/providers/hover.spec.ts
@@ -25,7 +25,7 @@ storage.set('file.scss', {
 	imports: []
 });
 
-function getHover(lines: string[]): Hover | null {
+function getHover(lines: string[]): Promise<Hover | null> {
 	const text = lines.join('\n');
 
 	const document = helpers.makeDocument(text);
@@ -35,8 +35,8 @@ function getHover(lines: string[]): Hover | null {
 }
 
 describe('Providers/Hover', () => {
-	it('should suggest local symbols', () => {
-		const actual = getHover([
+	it('should suggest local symbols', async () => {
+		const actual = await getHover([
 			'$one: 1;',
 			'.a { content: $one|; }'
 		]);
@@ -47,8 +47,8 @@ describe('Providers/Hover', () => {
 		});
 	});
 
-	it('should suggest global variables', () => {
-		const actual = getHover([
+	it('should suggest global variables', async () => {
+		const actual = await getHover([
 			'.a { content: $variable|; }'
 		]);
 
@@ -58,8 +58,8 @@ describe('Providers/Hover', () => {
 		});
 	});
 
-	it('should suggest global mixins', () => {
-		const actual = getHover([
+	it('should suggest global mixins', async () => {
+		const actual = await getHover([
 			'@include mixin|'
 		]);
 
@@ -70,8 +70,8 @@ describe('Providers/Hover', () => {
 	});
 
 	// Does not work right now
-	it.skip('should suggest global functions', () => {
-		const actual = getHover([
+	it.skip('should suggest global functions', async () => {
+		const actual = await getHover([
 			'.a { content: make|(); }'
 		]);
 

--- a/src/test/providers/signatureHelp.spec.ts
+++ b/src/test/providers/signatureHelp.spec.ts
@@ -60,7 +60,7 @@ storage.set('one.scss', {
 	imports: []
 });
 
-function getSignatureHelp(lines: string[]): SignatureHelp {
+function getSignatureHelp(lines: string[]): Promise<SignatureHelp> {
 	const text = lines.join('\n');
 
 	const document = helpers.makeDocument(text);
@@ -70,88 +70,88 @@ function getSignatureHelp(lines: string[]): SignatureHelp {
 }
 
 describe('Providers/SignatureHelp - Empty', () => {
-	it('Empty', () => {
-		const actual = getSignatureHelp(['@include one(|']);
+	it('Empty', async () => {
+		const actual = await getSignatureHelp(['@include one(|']);
 
 		assert.equal(actual.signatures.length, 1);
 	});
-	it('Closed without parameters', () => {
-		const actual = getSignatureHelp(['@include two(|)']);
+	it('Closed without parameters', async () => {
+		const actual = await getSignatureHelp(['@include two(|)']);
 
 		assert.equal(actual.signatures.length, 3);
 	});
 
-	it('Closed with parameters', () => {
-		const actual = getSignatureHelp(['@include two(1);']);
+	it('Closed with parameters', async () => {
+		const actual = await getSignatureHelp(['@include two(1);']);
 
 		assert.equal(actual.signatures.length, 0);
 	});
 });
 
 describe('Providers/SignatureHelp - Two parameters', () => {
-	it('Passed one parameter of two', () => {
-		const actual = getSignatureHelp(['@include two(1,|']);
+	it('Passed one parameter of two', async () => {
+		const actual = await getSignatureHelp(['@include two(1,|']);
 
 		assert.equal(actual.activeParameter, 1, 'activeParameter');
 		assert.equal(actual.signatures.length, 2, 'signatures.length');
 	});
 
-	it('Passed two parameter of two', () => {
-		const actual = getSignatureHelp(['@include two(1, 2,|']);
+	it('Passed two parameter of two', async () => {
+		const actual = await getSignatureHelp(['@include two(1, 2,|']);
 
 		assert.equal(actual.activeParameter, 2, 'activeParameter');
 		assert.equal(actual.signatures.length, 1, 'signatures.length');
 	});
 
-	it('Passed three parameters of two', () => {
-		const actual = getSignatureHelp(['@include two(1, 2, 3,|']);
+	it('Passed three parameters of two', async () => {
+		const actual = await getSignatureHelp(['@include two(1, 2, 3,|']);
 
 		assert.equal(actual.signatures.length, 0);
 	});
 
-	it('Passed two parameter of two with parenthesis', () => {
-		const actual = getSignatureHelp(['@include two(1, 2)|']);
+	it('Passed two parameter of two with parenthesis', async () => {
+		const actual = await getSignatureHelp(['@include two(1, 2)|']);
 
 		assert.equal(actual.signatures.length, 0);
 	});
 });
 
 describe('Providers/SignatureHelp - parseArgumentsAtLine for Mixins', () => {
-	it('RGBA', () => {
-		const actual = getSignatureHelp(['@include two(rgba(0,0,0,.0001),|']);
+	it('RGBA', async () => {
+		const actual = await getSignatureHelp(['@include two(rgba(0,0,0,.0001),|']);
 
 		assert.equal(actual.activeParameter, 1, 'activeParameter');
 		assert.equal(actual.signatures.length, 2, 'signatures.length');
 	});
 
-	it('RGBA when typing', () => {
-		const actual = getSignatureHelp(['@include two(rgba(0,0,0,|']);
+	it('RGBA when typing', async () => {
+		const actual = await getSignatureHelp(['@include two(rgba(0,0,0,|']);
 
 		assert.equal(actual.activeParameter, 0, 'activeParameter');
 		assert.equal(actual.signatures.length, 3, 'signatures.length');
 	});
 
-	it('Quotes', () => {
-		const actual = getSignatureHelp(['@include two("\\",;",|']);
+	it('Quotes', async () => {
+		const actual = await getSignatureHelp(['@include two("\\",;",|']);
 
 		assert.equal(actual.activeParameter, 1, 'activeParameter');
 		assert.equal(actual.signatures.length, 2, 'signatures.length');
 	});
 
-	it('With overload', () => {
-		const actual = getSignatureHelp(['@include two(|']);
+	it('With overload', async () => {
+		const actual = await getSignatureHelp(['@include two(|']);
 
 		assert.equal(actual.signatures.length, 3);
 	});
 
-	it('Single-line selector', () => {
-		const actual = getSignatureHelp(['h1 { @include two(1,| }']);
+	it('Single-line selector', async () => {
+		const actual = await getSignatureHelp(['h1 { @include two(1,| }']);
 
 		assert.equal(actual.signatures.length, 2);
 	});
 
-	it('Single-line Mixin reference', () => {
-		const actual = getSignatureHelp([
+	it('Single-line Mixin reference', async () => {
+		const actual = await getSignatureHelp([
 			'h1 {',
 			'    @include two(1, 2);',
 			'    @include two(1,|)',
@@ -160,72 +160,72 @@ describe('Providers/SignatureHelp - parseArgumentsAtLine for Mixins', () => {
 		assert.equal(actual.signatures.length, 2);
 	});
 
-	it('Mixin with named argument', () => {
-		const actual = getSignatureHelp(['@include two($a: 1,|']);
+	it('Mixin with named argument', async () => {
+		const actual = await getSignatureHelp(['@include two($a: 1,|']);
 
 		assert.equal(actual.signatures.length, 2);
 	});
 });
 
 describe('Providers/SignatureHelp - parseArgumentsAtLine for Functions', () => {
-	it('Empty', () => {
-		const actual = getSignatureHelp(['content: make(|']);
+	it('Empty', async () => {
+		const actual = await getSignatureHelp(['content: make(|']);
 
 		assert.equal(actual.signatures.length, 1, 'length');
 		assert.ok(actual.signatures[0].label.startsWith('make'), 'name');
 	});
 
-	it('Single-line Function reference', () => {
-		const actual = getSignatureHelp(['content: make()+make(|']);
+	it('Single-line Function reference', async () => {
+		const actual = await getSignatureHelp(['content: make()+make(|']);
 
 		assert.equal(actual.signatures.length, 1, 'length');
 		assert.ok(actual.signatures[0].label.startsWith('make'), 'name');
 	});
 
-	it('Inside another uncompleted function', () => {
-		const actual = getSignatureHelp(['content: attr(make(|']);
+	it('Inside another uncompleted function', async () => {
+		const actual = await getSignatureHelp(['content: attr(make(|']);
 
 		assert.equal(actual.signatures.length, 1, 'length');
 		assert.ok(actual.signatures[0].label.startsWith('make'), 'name');
 	});
 
-	it('Inside another completed function', () => {
-		const actual = getSignatureHelp(['content: attr(one(1, two(1, two(1, 2)),|']);
+	it('Inside another completed function', async () => {
+		const actual = await getSignatureHelp(['content: attr(one(1, two(1, two(1, 2)),|']);
 
 		assert.equal(actual.signatures.length, 1, 'length');
 		assert.ok(actual.signatures[0].label.startsWith('one'), 'name');
 	});
 
-	it('Inside several completed functions', () => {
-		const actual = getSignatureHelp(['background: url(one(1, one(1, 2, two(1, 2)),|']);
+	it('Inside several completed functions', async () => {
+		const actual = await getSignatureHelp(['background: url(one(1, one(1, 2, two(1, 2)),|']);
 
 		assert.equal(actual.signatures.length, 1, 'length');
 		assert.ok(actual.signatures[0].label.startsWith('one'), 'name');
 	});
 
-	it('Inside another function with CSS function', () => {
-		const actual = getSignatureHelp(['background-color: make(rgba(|']);
+	it('Inside another function with CSS function', async () => {
+		const actual = await getSignatureHelp(['background-color: make(rgba(|']);
 
 		assert.equal(actual.signatures.length, 1, 'length');
 		assert.ok(actual.signatures[0].label.startsWith('make'), 'name');
 	});
 
-	it('Inside another function with uncompleted CSS function', () => {
-		const actual = getSignatureHelp(['background-color: make(rgba(1, 1,2,|']);
+	it('Inside another function with uncompleted CSS function', async () => {
+		const actual = await getSignatureHelp(['background-color: make(rgba(1, 1,2,|']);
 
 		assert.equal(actual.signatures.length, 1, 'length');
 		assert.ok(actual.signatures[0].label.startsWith('make'), 'name');
 	});
 
-	it('Inside another function with completed CSS function', () => {
-		const actual = getSignatureHelp(['background-color: make(rgba(1,2, 3,.5)|']);
+	it('Inside another function with completed CSS function', async () => {
+		const actual = await getSignatureHelp(['background-color: make(rgba(1,2, 3,.5)|']);
 
 		assert.equal(actual.signatures.length, 1, 'length');
 		assert.ok(actual.signatures[0].label.startsWith('make'), 'name');
 	});
 
-	it('Interpolation', () => {
-		const actual = getSignatureHelp(['background-color: "#{make(|}"']);
+	it('Interpolation', async () => {
+		const actual = await getSignatureHelp(['background-color: "#{make(|}"']);
 
 		assert.equal(actual.signatures.length, 1, 'length');
 		assert.ok(actual.signatures[0].label.startsWith('make'), 'name');

--- a/src/test/providers/workspaceSymbol.spec.ts
+++ b/src/test/providers/workspaceSymbol.spec.ts
@@ -23,11 +23,15 @@ storage.set('one.scss', {
 });
 
 describe('Providers/WorkspaceSymbol', () => {
-	it('searchWorkspaceSymbol - Empty query', () => {
-		assert.equal(searchWorkspaceSymbol('', storage, '').length, 3);
+	it('searchWorkspaceSymbol - Empty query', async () => {
+		const actual = await searchWorkspaceSymbol('', storage, '');
+
+		assert.equal(actual.length, 3);
 	});
 
-	it('searchWorkspaceSymbol - Non-empty query', () => {
-		assert.equal(searchWorkspaceSymbol('$', storage, '').length, 1);
+	it('searchWorkspaceSymbol - Non-empty query', async () => {
+		const actual = await searchWorkspaceSymbol('$', storage, '');
+
+		assert.equal(actual.length, 1);
 	});
 });

--- a/src/test/services/parser.spec.ts
+++ b/src/test/services/parser.spec.ts
@@ -11,7 +11,7 @@ import { IImport } from '../../types/symbols';
 
 describe('Services/Parser', () => {
 	describe('.parseDocument', () => {
-		it('should return symbols', () => {
+		it('should return symbols', async () => {
 			const document = helpers.makeDocument([
 				'@import "file.scss";',
 				'$name: "value";',
@@ -19,7 +19,7 @@ describe('Services/Parser', () => {
 				'@function function($a: 1, $b) {}'
 			]);
 
-			const { symbols } = parseDocument(document, null);
+			const { symbols } = await parseDocument(document, null);
 
 			// Variables
 			assert.equal(symbols.variables.length, 1);
@@ -57,18 +57,18 @@ describe('Services/Parser', () => {
 			assert.equal(symbols.imports[0].filepath, 'file.scss');
 		});
 
-		it('should include references as imports', () => {
+		it('should include references as imports', async () => {
 			const document = helpers.makeDocument([
 				'// <reference path="file">'
 			]);
 
-			const { symbols } = parseDocument(document);
+			const { symbols } = await parseDocument(document);
 
 			assert.equal(symbols.imports[0].filepath, 'file.scss');
 			assert.ok(symbols.imports[0].reference);
 		});
 
-		it('should return Node at offset', () => {
+		it('should return Node at offset', async () => {
 			const lines = [
 				'$name: "value";',
 				'@mixin mixin($a: 1, $b) {}',
@@ -80,7 +80,7 @@ describe('Services/Parser', () => {
 			const document = helpers.makeDocument(lines);
 			const offset = lines.join('\n').indexOf('|');
 
-			const { node } = parseDocument(document, offset);
+			const { node } = await parseDocument(document, offset);
 
 			assert.equal(node.type, NodeType.Identifier);
 		});

--- a/src/utils/document.ts
+++ b/src/utils/document.ts
@@ -1,6 +1,11 @@
 'use strict';
 
 import * as path from 'path';
+import * as url from 'url';
+
+import { DocumentContext } from 'vscode-css-languageservice';
+import { URI } from 'vscode-uri';
+import { fileExistsSync } from '../utils/fs';
 
 /**
  * Returns the path to the document, relative to the current document.
@@ -14,4 +19,56 @@ export function getDocumentPath(currentPath: string, symbolsPath: string): strin
 	}
 
 	return docPath.replace(/\\/g, '/');
+}
+
+/**
+ * Primary copied from the original VSCode CSS extension:
+ * https://github.com/microsoft/vscode/blob/2bb6cfc16a88281b75cfdaced340308ff89a849e/extensions/css-language-features/server/src/utils/documentContext.ts
+ */
+export function buildDocumentContext(base: string): DocumentContext {
+	return {
+		resolveReference: ref => {
+			// Following [css-loader](https://github.com/webpack-contrib/css-loader#url)
+			// And [sass-loader's](https://github.com/webpack-contrib/sass-loader#imports)
+			// Convention, if an import path starts with ~ then use node module resolution
+			// *unless* it starts with "~/" as this refers to the user's home directory.
+			if (ref[0] === '~' && ref[1] !== '/') {
+				ref = ref.substring(1);
+
+				if (base.startsWith('file:')) {
+					const moduleName = getModuleNameFromPath(ref);
+					const modulePath = resolvePathToModule(moduleName, base);
+
+					if (modulePath) {
+						return url.resolve(modulePath, ref);
+					}
+				}
+			}
+
+			return url.resolve(base, ref);
+		}
+	};
+}
+
+export function getModuleNameFromPath(filepath: string) {
+	/**
+	 * If a scoped module (starts with @) then get up until second instance of '/',
+	 * otherwise get until first instance of '/'.
+	 */
+	if (filepath[0] === '@') {
+		return filepath.substring(0, filepath.indexOf('/', filepath.indexOf('/') + 1));
+	}
+
+	return filepath.substring(0, filepath.indexOf('/'));
+}
+
+export function resolvePathToModule(moduleName: string, relativeTo: string): string | undefined {
+	const documentFolder = path.dirname(URI.parse(relativeTo).fsPath);
+	const packageDirectory = path.join(documentFolder, 'node_modules', moduleName);
+
+	if (fileExistsSync(packageDirectory)) {
+		return URI.file(packageDirectory).toString();
+	}
+
+	return undefined;
 }

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -21,6 +21,10 @@ export function fileExists(filepath: string): Promise<boolean> {
 	});
 }
 
+export function fileExistsSync(filepath: string): boolean {
+	return fs.existsSync(filepath);
+}
+
 /**
  * Read file by specified filepath;
  */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2029,11 +2029,6 @@ vscode-test@^1.2.3:
     https-proxy-agent "^2.2.4"
     rimraf "^2.6.3"
 
-vscode-uri@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-1.0.0.tgz#07369e2d096bfe42b406bd21860b5aa4fe7a7ad0"
-  integrity sha1-BzaeLQlr/kK0Br0hhgtapP56etA=
-
 vscode-uri@^1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-1.0.8.tgz#9769aaececae4026fb6e22359cb38946580ded59"

--- a/yarn.lock
+++ b/yarn.lock
@@ -37,6 +37,11 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
+"@nodelib/fs.macchiato@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.macchiato/-/fs.macchiato-1.0.2.tgz#9f7df4a752306037315221dbe3ee91e59a316d56"
+  integrity sha512-y0KHcT86IFuG0BZV59OYR1r1eypJ++Ii8zJE+cwwDn2WNYMkjsMxZulBbVEGSq4JvkTIGsWpm8T23QKvlMvvHA==
+
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
@@ -135,10 +140,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.7.tgz#01e4ea724d9e3bd50d90c11fd5980ba317d8fa11"
   integrity sha512-E6Zn0rffhgd130zbCbAr/JdXfXkoOUFAKNs/rF8qnafSJ8KYaA/j3oz7dcwal+lYjLA7xvdd5J4wdYpCTlP8+w==
 
-"@types/node@^7.0.31":
-  version "7.10.9"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.10.9.tgz#4343e3b009f8cf5e1ed685e36097b74b4101e880"
-  integrity sha512-usSpgoUsRtO5xNV5YEPU8PPnHisFx8u0rokj1BPVn/hDF7zwUDzVLiuKZM38B7z8V2111Fj6kd4rGtQFUZpNOw==
+"@types/node@10.17.6":
+  version "10.17.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.6.tgz#1aaabd6f6470a6ac3824ab1e94d731ca1326d93d"
+  integrity sha512-0a2X6cgN3RdPBL2MIlR6Lt0KlM7fOFsutuXcdglcOq6WvLnYXgPQSh0Mx6tO1KCAE8MxbHSOSTWDoUxRq+l3DA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
This is a fix for #99.

Yeap, right now it looks dirty. But in the future I would like to separate the concept of parser and link search. Something like:

https://github.com/microsoft/vscode/blob/2bb6cfc16a88281b75cfdaced340308ff89a849e/extensions/css-language-features/server/src/cssServerMain.ts#L231-L249