### PR TITLE
Allow scanninng only specific location instead of whole workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ Just install the plugin and use it.
 
 ## Supported settings
 
+#### scss.scannerRoot
+
+* Type: `string`
+* Default: `""`
+
+Set root directory for the scanner, relative to your workspace. `""` means whole workspace will be scanned. If your workspace has many .scss files unrelated to your current work, you should point the scanner to more specific location eg. `"themes/my-theme/src/scss"`.
+
 #### scss.scannerDepth
 
 * Type: `number`

--- a/package.json
+++ b/package.json
@@ -32,6 +32,11 @@
 	"contributes": {
 		"configuration": {
 			"properties": {
+				"scss.scannerRoot": {
+					"type": "string",
+					"default": "",
+					"description": "Set root directory for the scanner, relative to your workspace. `\"\"` means whole workspace will be scanned. If your workspace has many .scss files unrelated to your current work, you should point the scanner to more specific location eg. `\"themes/my-theme/src/scss\"`."
+				},
 				"scss.scannerDepth": {
 					"type": "number",
 					"default": 30,

--- a/src/unsafe/server.ts
+++ b/src/unsafe/server.ts
@@ -25,6 +25,7 @@ import { searchWorkspaceSymbol } from './providers/workspaceSymbol';
 import { findFiles } from './utils/fs';
 import { getSCSSRegionsDocument } from './utils/vue';
 import { URI } from 'vscode-uri';
+import * as path from 'path';
 
 interface InitializationOption {
 	workspace: string;
@@ -56,8 +57,8 @@ connection.onInitialize(
 	async (params: InitializeParams): Promise<InitializeResult> => {
 		const options = params.initializationOptions as InitializationOption;
 
-		workspaceRoot = options.workspace;
 		settings = options.settings;
+		workspaceRoot = path.join(options.workspace, settings.scannerRoot);
 
 		storageService = new StorageService();
 		scannerService = new ScannerService(storageService, settings);

--- a/src/unsafe/test/helpers.ts
+++ b/src/unsafe/test/helpers.ts
@@ -40,6 +40,7 @@ export function makeSameLineRange(line: number = 1, start: number = 1, end: numb
 
 export function makeSettings(options?: Partial<ISettings>): ISettings {
 	return {
+		scannerRoot: '',
 		scannerDepth: 30,
 		scannerExclude: ['**/.git', '**/node_modules', '**/bower_components'],
 		scanImportedFiles: true,

--- a/src/unsafe/types/settings.ts
+++ b/src/unsafe/types/settings.ts
@@ -2,6 +2,7 @@
 
 export interface ISettings {
 	// Scanner
+	scannerRoot: string;
 	scannerDepth: number;
 	scannerExclude: string[];
 	scanImportedFiles: boolean;


### PR DESCRIPTION
Fixes #153

Adds option `"scss.scannerRoot": ""`. Default value is empty string - in this case whole workspace is scanned. It allows to set more specific location where files should be scanned instead of messing up intellisense with duplicated variables from other locations in the workspace. Example:
#### /your/workspace/.vscode/settings.json
```
{
  scss.scannerRoot: "themes/my-new-theme/src/scss"
}
```
This will scan only .scss files in */your/workspace/themes/my-new-theme/src/scss* so you can remove all paths from `scss.scannerExclude` array that are outside `scss.scannerRoot` location