### PR TITLE
Fix #175: add missing enums for the AST node types. To match vscode-css-languageservice@5.1.1 values.

### DIFF
--- a/fixtures/e2e/_variables.scss
+++ b/fixtures/e2e/_variables.scss
@@ -1,1 +1,2 @@
 $variable: 'value';
+$variable2: min-width 1200px;

--- a/fixtures/e2e/definition/main.scss
+++ b/fixtures/e2e/definition/main.scss
@@ -2,4 +2,6 @@
   content: $variable + function();
 
   @include mixin();
+
+  @media ($variable2) {};
 }

--- a/src/unsafe/test/e2e/suite/definition/definitions.test.ts
+++ b/src/unsafe/test/e2e/suite/definition/definitions.test.ts
@@ -18,6 +18,12 @@ describe('SCSS Definition Test', () => {
 		await testDefinition(docUri, position(2, 13), expectedLocation);
 	});
 
+	it('should find definition for variables in media', async () => {
+		const expectedDocumentUri = getDocUri('_variables.scss');
+		const expectedLocation = sameLineLocation(expectedDocumentUri, 2, 1, 11);
+		await testDefinition(docUri, position(6, 12), expectedLocation);
+	});
+
 	it('should find definition for functions', async () => {
 		const expectedDocumentUri = getDocUri('_functions.scss');
 		const expectedLocation = sameLineLocation(expectedDocumentUri, 1, 1, 9);

--- a/src/unsafe/types/nodes.ts
+++ b/src/unsafe/types/nodes.ts
@@ -49,7 +49,8 @@ export enum NodeType {
 	For,
 	Each,
 	While,
-	MixinContent,
+	MixinContentReference,
+	MixinContentDeclaration,
 	Media,
 	Keyframe,
 	FontFace,
@@ -67,7 +68,18 @@ export enum NodeType {
 	AtApplyRule,
 	CustomPropertyDeclaration,
 	CustomPropertySet,
-	ListEntry
+	ListEntry,
+	Supports,
+	SupportsCondition,
+	NamespacePrefix,
+	GridLine,
+	Plugin,
+	UnknownAtRule,
+	Use,
+	ModuleConfiguration,
+	Forward,
+	ForwardVisibility,
+	Module
 }
 
 export interface INode {


### PR DESCRIPTION
this will fix variables in the `MediaQuery` being recognized as `FunctionParameter` and be ignored.

The issue was that some enums from [vscode-css-languageservice@5.1.1](https://github.com/microsoft/vscode-css-languageservice/blob/v5.1.1/src/parser/cssNodes.ts) (i.e. `MixinContentDeclaration`) were missing and lead to the indexes coming after it (how typescript compares enums) being off by one. and the variable inside the media query (e.g. `@media ($var)`) being recognized as `FunctionParameter` index 58, instead of `MediaQuery` being at this index.

